### PR TITLE
L2 - Fallback Authorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ This is an example of request for authorize a transaction. (All the fields are r
 ```
 
 #### Transaction Authorization Rules
-- If `mcc` is `"5411"` or `"5412"`, the `FOOD` balance will be used.<br>
-- If `mcc` is `"5811"` or `"5812"`, the `MEAL` balance will be used.<br>
+- If `mcc` is `"5411"` or `"5412"`, the `FOOD` balance will be used.
+- If `mcc` is `"5811"` or `"5812"`, the `MEAL` balance will be used.
 - For any other `mcc` values, the `CASH` balance will be used as fallback.
 - If the benefit balance has insufficient amount then `CASH` balance will be used as fallback.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ This is an example of request for authorize a transaction. (All the fields are r
 #### Transaction Authorization Rules
 - If `mcc` is `"5411"` or `"5412"`, the `FOOD` balance will be used.<br>
 - If `mcc` is `"5811"` or `"5812"`, the `MEAL` balance will be used.<br>
-- For any other `mcc` values, the application will treat as invalid.
+- For any other `mcc` values, the `CASH` balance will be used as fallback.
+- If the benefit balance has insufficient amount then `CASH` balance will be used as fallback.
 
 #### Possible Responses
 - `{ "code": "00" }` if the transaction is **approved**

--- a/src/main/java/br/com/caju/authorizer/domain/model/BenefitBalance.java
+++ b/src/main/java/br/com/caju/authorizer/domain/model/BenefitBalance.java
@@ -1,5 +1,6 @@
 package br.com.caju.authorizer.domain.model;
 
+import br.com.caju.authorizer.enums.BalanceType;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -17,8 +18,9 @@ public abstract class BenefitBalance {
     @Column(name = "benefit_balance_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "balance_type", insertable = false, updatable = false)
-    private String balanceType;
+    private BalanceType balanceType;
 
     private BigDecimal amount;
 

--- a/src/main/java/br/com/caju/authorizer/domain/model/CashBalance.java
+++ b/src/main/java/br/com/caju/authorizer/domain/model/CashBalance.java
@@ -1,0 +1,13 @@
+package br.com.caju.authorizer.domain.model;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@Entity
+@DiscriminatorValue("CASH")
+@EqualsAndHashCode(callSuper = false)
+public class CashBalance extends BenefitBalance {
+}

--- a/src/main/java/br/com/caju/authorizer/domain/vo/BenefitBalanceVO.java
+++ b/src/main/java/br/com/caju/authorizer/domain/vo/BenefitBalanceVO.java
@@ -1,6 +1,8 @@
 package br.com.caju.authorizer.domain.vo;
 
+import br.com.caju.authorizer.enums.BalanceType;
+
 import java.math.BigDecimal;
 
-public record BenefitBalanceVO(String balanceType, BigDecimal totalAmount) {
+public record BenefitBalanceVO(BalanceType balanceType, BigDecimal totalAmount) {
 }

--- a/src/main/java/br/com/caju/authorizer/enums/BalanceType.java
+++ b/src/main/java/br/com/caju/authorizer/enums/BalanceType.java
@@ -1,0 +1,9 @@
+package br.com.caju.authorizer.enums;
+
+public enum BalanceType {
+
+    FOOD,
+    MEAL,
+    CASH
+
+}

--- a/src/main/java/br/com/caju/authorizer/exception/InvalidMccException.java
+++ b/src/main/java/br/com/caju/authorizer/exception/InvalidMccException.java
@@ -1,9 +1,0 @@
-package br.com.caju.authorizer.exception;
-
-public class InvalidMccException extends RuntimeException {
-
-    public InvalidMccException() {
-        super("the given mcc is invalid");
-    }
-
-}

--- a/src/main/java/br/com/caju/authorizer/repository/BenefitBalanceRepository.java
+++ b/src/main/java/br/com/caju/authorizer/repository/BenefitBalanceRepository.java
@@ -2,6 +2,7 @@ package br.com.caju.authorizer.repository;
 
 import br.com.caju.authorizer.domain.model.Account;
 import br.com.caju.authorizer.domain.model.BenefitBalance;
+import br.com.caju.authorizer.enums.BalanceType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -12,7 +13,7 @@ import java.util.Optional;
 @Repository
 public interface BenefitBalanceRepository extends JpaRepository<BenefitBalance, Long> {
 
-    Optional<BenefitBalance> findByAccountAndBalanceType(Account account, String balanceType);
+    Optional<BenefitBalance> findByAccountAndBalanceType(Account account, BalanceType balanceType);
 
     @Query("Select bb From BenefitBalance bb " +
             "Inner Join bb.account acc " +

--- a/src/main/java/br/com/caju/authorizer/repository/CashBalanceRepository.java
+++ b/src/main/java/br/com/caju/authorizer/repository/CashBalanceRepository.java
@@ -1,0 +1,15 @@
+package br.com.caju.authorizer.repository;
+
+import br.com.caju.authorizer.domain.model.Account;
+import br.com.caju.authorizer.domain.model.CashBalance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface CashBalanceRepository extends JpaRepository<CashBalance, Long> {
+
+    Optional<CashBalance> findByAccount(Account account);
+
+}

--- a/src/main/java/br/com/caju/authorizer/service/BenefitBalanceService.java
+++ b/src/main/java/br/com/caju/authorizer/service/BenefitBalanceService.java
@@ -3,6 +3,7 @@ package br.com.caju.authorizer.service;
 import br.com.caju.authorizer.domain.model.Account;
 import br.com.caju.authorizer.domain.model.BenefitBalance;
 import br.com.caju.authorizer.domain.model.CashBalance;
+import br.com.caju.authorizer.enums.BalanceType;
 import br.com.caju.authorizer.exception.InsufficientBalanceException;
 import br.com.caju.authorizer.exception.InvalidAmountException;
 import br.com.caju.authorizer.repository.BenefitBalanceRepository;
@@ -27,7 +28,7 @@ public class BenefitBalanceService {
 
     protected static final List<Integer> FOOD_CODES = Arrays.asList(5411, 5412);
     protected static final List<Integer> MEAL_CODES = Arrays.asList(5811, 5812);
-    protected static final Map<String, List<Integer>> MCC_MAP = Map.of("FOOD", FOOD_CODES, "MEAL", MEAL_CODES);
+    protected static final Map<BalanceType, List<Integer>> MCC_MAP = Map.of(BalanceType.FOOD, FOOD_CODES, BalanceType.MEAL, MEAL_CODES);
 
     private final BenefitBalanceRepository repository;
     private final CashBalanceRepository cashBalanceRepository;
@@ -54,12 +55,12 @@ public class BenefitBalanceService {
     //******************************************* PRIVATE/PROTECTED METHODS *******************************************
     //*****************************************************************************************************************
 
-    private String findBalanceTypeByMcc(Integer mcc) {
+    private BalanceType findBalanceTypeByMcc(Integer mcc) {
         return MCC_MAP.entrySet().stream()
                 .filter(entry -> entry.getValue().contains(mcc))
                 .map(Map.Entry::getKey)
                 .findFirst()
-                .orElse("CASH");
+                .orElse(BalanceType.CASH);
     }
 
     private BenefitBalance checkBalanceAndAmount(BenefitBalance balance, BigDecimal amount) {

--- a/src/main/resources/docs/authorizer-swagger.yaml
+++ b/src/main/resources/docs/authorizer-swagger.yaml
@@ -104,7 +104,8 @@ components:
             Rules:<br>
             - If the MCC is "5411" or "5412", the FOOD balance will be used.<br>
             - If the MCC is "5811" or "5812", the MEAL balance will be used.<br>
-            - For any other MCC values, the response will be an error.<br>
+            - For any other MCC values, the CASH balance will be used as fallback.<br>
+            - If the benefit balance has insufficient amount then CASH balance will be used as fallback.<br>
           example: 5411
         merchant:
           type: string

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -2,4 +2,4 @@
 INSERT INTO account_tb (owner) VALUES ('Alice Johnson'), ('Bob Smith'), ('Carol White'), ('David Brown'), ('Eva Green');
 
 -- Balances
-INSERT INTO benefit_balance_tb (amount, account_id, balance_type) VALUES (600, 1, 'FOOD'), (400, 1, 'MEAL'), (450, 2, 'FOOD'), (550, 2, 'MEAL'), (300, 3, 'FOOD'), (700, 3, 'MEAL'), (400, 4, 'FOOD'), (600, 4, 'MEAL'), (500, 5, 'FOOD'), (500, 5, 'MEAL');
+INSERT INTO benefit_balance_tb (amount, account_id, balance_type) VALUES (600, 1, 'FOOD'), (400, 1, 'MEAL'), (700, 1, 'CASH'),(450, 2, 'FOOD'), (550, 2, 'MEAL'), (400, 2, 'CASH'), (300, 3, 'FOOD'), (700, 3, 'MEAL'), (900, 3, 'CASH'), (400, 4, 'FOOD'), (600, 4, 'MEAL'), (50, 4, 'CASH'), (500, 5, 'FOOD'), (500, 5, 'MEAL'), (150, 5, 'CASH');

--- a/src/test/java/br/com/caju/authorizer/controller/BenefitBalanceControllerTests.java
+++ b/src/test/java/br/com/caju/authorizer/controller/BenefitBalanceControllerTests.java
@@ -3,6 +3,7 @@ package br.com.caju.authorizer.controller;
 import br.com.caju.authorizer.domain.model.FoodBalance;
 import br.com.caju.authorizer.domain.model.MealBalance;
 import br.com.caju.authorizer.domain.vo.BenefitBalanceVO;
+import br.com.caju.authorizer.enums.BalanceType;
 import br.com.caju.authorizer.service.BenefitBalanceService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -47,7 +48,7 @@ public class BenefitBalanceControllerTests {
         basePath = "/v1/benefits/balance";
         mapper = JsonMapper.builder().findAndAddModules().build();
         foodBalance = new FoodBalance();
-        foodBalance.setBalanceType("FOOD");
+        foodBalance.setBalanceType(BalanceType.FOOD);
         foodBalance.setAmount(NumberUtils.toScaledBigDecimal(500.00));
         mealBalance = new MealBalance();
         mealBalance.setAmount(NumberUtils.toScaledBigDecimal(300.00));

--- a/src/test/java/br/com/caju/authorizer/controller/TransactionControllerTests.java
+++ b/src/test/java/br/com/caju/authorizer/controller/TransactionControllerTests.java
@@ -3,7 +3,6 @@ package br.com.caju.authorizer.controller;
 import br.com.caju.authorizer.domain.vo.TransactionVO;
 import br.com.caju.authorizer.exception.InsufficientBalanceException;
 import br.com.caju.authorizer.exception.InvalidAmountException;
-import br.com.caju.authorizer.exception.InvalidMccException;
 import br.com.caju.authorizer.records.TransactionResponseVO;
 import br.com.caju.authorizer.service.TransactionService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -23,9 +22,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static io.restassured.module.mockmvc.RestAssuredMockMvc.given;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.*;
 
 @AutoConfigureMockMvc
@@ -110,17 +109,17 @@ public class TransactionControllerTests {
     }
 
     @Test
-    public void givenInvalidMcc_whenAuthorizeTransaction_thenReturnCode07() throws JsonProcessingException {
+    public void givenInvalidMcc_whenAuthorizeTransaction_thenReturnCode00() throws JsonProcessingException {
         var request = TransactionVO.builder().account("123").merchant("Test")
                 .mcc(9999).totalAmount(NumberUtils.toScaledBigDecimal(100.00)).build();
-        doThrow(InvalidMccException.class).when(service).authorizeTransaction(any(), anyString());
+        doNothing().when(service).authorizeTransaction(any(), anyString());
 
         given().contentType(ContentType.JSON).body(request)
                 .when().post(basePath + "/authorize")
                 .then().log().ifValidationFails()
                 .status(HttpStatus.OK)
                 .body(notNullValue(), not(emptyString()))
-                .body(equalTo(mapper.writeValueAsString(errorResponse)));
+                .body(equalTo(mapper.writeValueAsString(successResponse)));
     }
 
     @Test


### PR DESCRIPTION
Para despesas não relacionadas a benefícios, criamos outra categoria, chamada CASH.
O autorizador com fallback deve funcionar como o autorizador simples, com a seguinte diferença:
- Se a MCC não puder ser mapeado para uma categoria de benefícios ou se o saldo da categoria fornecida não for suficiente para pagar a transação inteira, verifica o saldo de CASH e, se for suficiente, debita esse saldo.