### PR TITLE
L3 - Merchant MCC override

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,19 @@ This is an example of request for authorize a transaction. (All the fields are r
 - If `mcc` is `"5811"` or `"5812"`, the `MEAL` balance will be used.
 - For any other `mcc` values, the `CASH` balance will be used as fallback.
 - If the benefit balance has insufficient amount then `CASH` balance will be used as fallback.
+- Sometimes, the `mcc` are incorrect and a transaction must be processed taking into account the merchant's data as well. Register merchants using the `import.sql` file located at `src/main/resources/` to make sure that the name will be considered.
+
+#### Default Merchants
+
+```
+Merchant Name             Type
+-------------------------------
+UBER EATS                 MEAL
+PADARIA DO ZE             FOOD
+RESTAURANTE DA MARIA      MEAL
+SUPERMERCADOS BH          FOOD
+```
+* **Remember**: For more merchants just add them in the insert query on `import.sql`
 
 #### Possible Responses
 - `{ "code": "00" }` if the transaction is **approved**

--- a/src/main/java/br/com/caju/authorizer/domain/model/Merchant.java
+++ b/src/main/java/br/com/caju/authorizer/domain/model/Merchant.java
@@ -1,0 +1,30 @@
+package br.com.caju.authorizer.domain.model;
+
+import br.com.caju.authorizer.enums.BalanceType;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Table(name = "merchant_tb")
+@Data @Builder
+@NoArgsConstructor @AllArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Merchant {
+
+    @Id
+    @EqualsAndHashCode.Include
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "merchant_id")
+    private Long id;
+
+    @NotBlank
+    @Column(name = "name", unique = true)
+    private String name;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private BalanceType balanceType;
+
+}

--- a/src/main/java/br/com/caju/authorizer/repository/MerchantRepository.java
+++ b/src/main/java/br/com/caju/authorizer/repository/MerchantRepository.java
@@ -1,0 +1,14 @@
+package br.com.caju.authorizer.repository;
+
+import br.com.caju.authorizer.domain.model.Merchant;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MerchantRepository extends JpaRepository<Merchant, Long> {
+
+    Optional<Merchant> findByName(String name);
+
+}

--- a/src/main/java/br/com/caju/authorizer/service/MerchantService.java
+++ b/src/main/java/br/com/caju/authorizer/service/MerchantService.java
@@ -1,0 +1,24 @@
+package br.com.caju.authorizer.service;
+
+import br.com.caju.authorizer.domain.model.Merchant;
+import br.com.caju.authorizer.repository.MerchantRepository;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor(onConstructor_ = { @Autowired })
+public class MerchantService {
+
+    private final MerchantRepository repository;
+
+    public Optional<Merchant> findByName(String name) {
+        Assert.isTrue(StringUtils.isNotBlank(name), "name cannot be blank");
+        return repository.findByName(name);
+    }
+
+}

--- a/src/main/java/br/com/caju/authorizer/service/TransactionService.java
+++ b/src/main/java/br/com/caju/authorizer/service/TransactionService.java
@@ -22,8 +22,11 @@ public class TransactionService {
         Assert.notNull(transaction, "transaction cannot be null");
         Assert.isTrue(StringUtils.isNotBlank(accountId), "accountId cannot be blank");
         var account = accountService.getReferenceById(Long.valueOf(accountId));
-        var benefitBalance = balanceService.findByAccountAndMcc(account, transaction.getMcc());
+        var benefitBalance = balanceService.findByAccountAndBalanceType(account, transaction.getMerchant());
         balanceService.debitBalance(benefitBalance, transaction.getTotalAmount());
+        if (!BenefitBalanceService.MCC_MAP.get(benefitBalance.getBalanceType()).contains(transaction.getMcc())) {
+            transaction.setMcc(BenefitBalanceService.MCC_MAP.get(benefitBalance.getBalanceType()).stream().findFirst().orElseThrow());
+        }
         transaction.setAccount(account);
         transaction.setId(null);
         repository.save(transaction);

--- a/src/main/resources/docs/authorizer-swagger.yaml
+++ b/src/main/resources/docs/authorizer-swagger.yaml
@@ -106,6 +106,7 @@ components:
             - If the MCC is "5811" or "5812", the MEAL balance will be used.<br>
             - For any other MCC values, the CASH balance will be used as fallback.<br>
             - If the benefit balance has insufficient amount then CASH balance will be used as fallback.<br>
+            - Sometimes, the MCCs are incorrect and a transaction must be processed taking into account the merchant's data as well. Register merchants using the import.sql file located at src/main/resources/ to make sure that the name will be considered.
           example: 5411
         merchant:
           type: string

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -3,3 +3,6 @@ INSERT INTO account_tb (owner) VALUES ('Alice Johnson'), ('Bob Smith'), ('Carol 
 
 -- Balances
 INSERT INTO benefit_balance_tb (amount, account_id, balance_type) VALUES (600, 1, 'FOOD'), (400, 1, 'MEAL'), (700, 1, 'CASH'),(450, 2, 'FOOD'), (550, 2, 'MEAL'), (400, 2, 'CASH'), (300, 3, 'FOOD'), (700, 3, 'MEAL'), (900, 3, 'CASH'), (400, 4, 'FOOD'), (600, 4, 'MEAL'), (50, 4, 'CASH'), (500, 5, 'FOOD'), (500, 5, 'MEAL'), (150, 5, 'CASH');
+
+-- Merchants
+INSERT INTO merchant_tb (name, balance_type) VALUES ('UBER EATS', 'MEAL'), ('PADARIA DO ZE', 'FOOD'), ('RESTAURANTE DA MARIA', 'MEAL'), ('SUPERMERCADOS BH', 'FOOD');


### PR DESCRIPTION
## L3.Dependente do comerciante

As vezes, os MCCs estão incorretos e uma transação deve ser processada levando em consideração também os dados do comerciante. Crie um mecanismo para substituir MCCs com base no nome do comerciante. O nome do comerciante tem maior precedência sobre as MCCs.